### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "illuminate/contracts": "^9.0|^10.0",
         "illuminate/support": "^9.0|^10.0",
         "maatwebsite/excel": "^3.1",
-        "psr/simple-cache": "^2.0",
+        "psr/simple-cache": "^2.0|^3.0",
         "spatie/laravel-package-tools": "^1.14"
     },
     "require-dev": {


### PR DESCRIPTION
add psr/simple-cache ^3.0

## Proposed changes

Add psr/simple-cache ^3.0 version to composer require dep to fix installation error:

 - konnco/filament-import 1.5 requires psr/simple-cache ^2.0 -> found psr/simple-cache[2.0.0] but the package is fixed to 3.0.0 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.


## Types of changes

- [ ]  ✨ New feature (non-breaking change which adds functionality)
- [x]  🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ]  ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ]  🧹 Code refactor
- [ ]  ✅ Build configuration change
- [ ]  📝 Documentation
- [ ]  🗑️ Chore

